### PR TITLE
Setup prod/dev okd config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ LABEL maintainer="Max Meinhold <mxmeinhold@gmail.com>"
 
 EXPOSE 8080
 
-ENV NODE_ENV production
-
 RUN mkdir /opt/vote
 WORKDIR /opt/vote
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="Max Meinhold <mxmeinhold@gmail.com>"
 
 EXPOSE 8080
 
-RUN mkdir /opt/vote
 WORKDIR /opt/vote
 
 # nvm install deps

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Computer Science House
+Copyright (c) 2020 Computer Science House
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,6 @@
 # Deployment instructions
 
-Vote is meant to be deployed on an OKD/Openshift cluster.
+Vote is meant to be deployed on an OKD/OpenShift cluster.
 This directory contains most of the files needed to do that, but doesn't include the config maps, since they contain secrets.
 You'll need to create 2 config maps, `vote` and `vote-dev`, which should look rather like this, but with placeholders filled in:
 ```yaml

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,26 @@
+# Deployment instructions
+
+Vote is meant to be deployed on an OKD/Openshift cluster.
+This directory contains most of the files needed to do that, but doesn't include the config maps, since they contain secrets.
+You'll need to create 2 config maps, `vote` and `vote-dev`, which should look rather like this, but with placeholders filled in:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <name of cm>
+  namespace: vote
+data:
+  DB_URL: mongodb://<user>:<password>@tide.csh.rit.edu/vote?ssl=true
+  NODE_ENV: <env>
+  REACT_APP_BASE_API_URL: https://vote.csh.rit.edu
+  REACT_APP_SSO_AUTHORITY: https://sso.csh.rit.edu/auth/realms/csh
+  REACT_APP_SSO_CLIENT_ID: vote
+```
+
+Once you have all the files together, plop them in a directory and run `oc create -fr <directory>`, and you should see resources start to spin up.
+
+
+## Updating an existing deployment
+
+Rather than `oc create`, you'll need `oc edit` or `oc replace`.
+Please try to keep any changes synchronised with this repository.

--- a/deploy/bc-dev.yaml
+++ b/deploy/bc-dev.yaml
@@ -3,7 +3,7 @@ kind: BuildConfig
 metadata:
   labels:
     app: vote
-  name: vote
+  name: vote-dev
   namespace: vote
 spec:
   successfulBuildsHistoryLimit: 3
@@ -14,13 +14,13 @@ spec:
         secret: "vote"
     - type: "ConfigChange"
   source:
-    ref: main
+    ref: develop
     git:
       uri: "https://github.com/ComputerScienceHouse/Vote.git"
   output:
     to:
       kind: ImageStreamTag
-      name: vote:latest
+      name: vote:develop
   runPolicy: SerialLatestOnly
   strategy:
     dockerStrategy: {}
@@ -31,4 +31,4 @@ spec:
   status:
     tags:
     - items:
-      tag: latest
+      tag: develop

--- a/deploy/dc-dev.yaml
+++ b/deploy/dc-dev.yaml
@@ -1,0 +1,49 @@
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: vote-dev
+  labels:
+    app: vote
+  namespace: vote
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    deploymentconfig: vote-dev
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        app: vote
+        deploymentconfig: vote-dev
+    spec:
+      containers:
+      - name: vote-http
+        image: vote-dev
+        envFrom:
+        - configMapRef:
+            name: vote-dev
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+  triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - vote-http
+      from:
+        kind: ImageStreamTag
+        name: vote:develop
+        namespace: vote

--- a/deploy/route-dev.yaml
+++ b/deploy/route-dev.yaml
@@ -17,6 +17,6 @@ spec:
     termination: edge
   to:
     kind: Service
-    name: vote
+    name: vote-dev
     weight: 100
   wildcardPolicy: None

--- a/deploy/service-dev.yaml
+++ b/deploy/service-dev.yaml
@@ -12,6 +12,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    deployment: vote-dev
+    deploymentconfig: vote-dev
   sessionAffinity: None
   type: ClusterIP

--- a/deploy/service-dev.yaml
+++ b/deploy/service-dev.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: vote
+  name: vote-dev
+  namespace: vote
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    deployment: vote-dev
+  sessionAffinity: None
+  type: ClusterIP

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -12,6 +12,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    deployment: vote
+    deploymentconfig: vote
   sessionAffinity: None
   type: ClusterIP


### PR DESCRIPTION
This sets up the configs to allow running a develop vs main branch.
Also adds some more instructions for deployment, and helps prevent someone from accidentally creating votes in the prod collections.

### Pre Merge Checklist:
- [ ] Get the app to properly read env variables, deprecate dotenv

### Post Merge Checklist:
- [ ] Create `main` branch
- [ ] Point bc/vote to main branch
- [ ] Point bc/vote-dev to develop branch
- [ ] Create 1.0.0 tag and release